### PR TITLE
Handle sites that send a relative path in the location header

### DIFF
--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,7 +1,7 @@
 'use strict'
 
 import { constants as h2constants } from 'http2'
-import { URL } from 'url'
+import { URL, parse } from 'url'
 
 import { Finally } from 'already'
 import { syncGuard } from 'callguard'
@@ -334,7 +334,14 @@ async function fetchImpl(
 					}
 
 					const status = '' + headers[ HTTP2_HEADER_STATUS ];
-					const location = '' + headers[ HTTP2_HEADER_LOCATION ];
+					let location = '' + headers[ HTTP2_HEADER_LOCATION ];
+					const locationHeader = '' + headers[ HTTP2_HEADER_LOCATION ];
+					const parsedLocation = parse(locationHeader);
+					// Some sites can send a relative path in the location header.
+					if ( parsedLocation.hostname === null) {
+						const parsedUrl = parse(url);
+						location = `${parsedUrl.protocol}//${parsedUrl.host}${headers[ HTTP2_HEADER_LOCATION ]}`;
+					}
 
 					const isRedirected = isRedirectStatus[ status ];
 

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -334,14 +334,15 @@ async function fetchImpl(
 					}
 
 					const status = '' + headers[ HTTP2_HEADER_STATUS ];
-					let location = '' + headers[ HTTP2_HEADER_LOCATION ];
-					const locationHeader = '' + headers[ HTTP2_HEADER_LOCATION ];
-					const parsedLocation = parse(locationHeader);
+					let location = headers[ HTTP2_HEADER_LOCATION ];
 					// Some sites can send a relative path in the location header.
-					if ( parsedLocation.hostname === null) {
-						const parsedUrl = parse(url);
-						location = `${parsedUrl.protocol}//${parsedUrl.host}${headers[ HTTP2_HEADER_LOCATION ]}`;
-					}
+					try {
+						const parsedLocation = parse(location);
+						if ( parsedLocation.hostname === null ) {
+							const parsedUrl = parse(url);
+							location = ( location ) ? `${parsedUrl.protocol}//${parsedUrl.hostname}${location}` : undefined;
+						}
+					} catch (TypeError) {}
 
 					const isRedirected = isRedirectStatus[ status ];
 


### PR DESCRIPTION
Some sites (for example, Bloomingdales) send a relative path in the location header. This PR handles those by reconstructing the full redirection URL by using the proto and hostname from the original URL.

Sample URL — [`https://www.bloomingdales.com/shop/product/whistles-rosa-polka-dot-tee?ID=2757111&CategoryID=2910`](https://www.bloomingdales.com/shop/product/whistles-rosa-polka-dot-tee?ID=2757111&CategoryID=2910)

CC: @grantila 