### PR TITLE
Avoid publishing tests to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ scripts
 .npmignore
 .travis.yml
 tsconfig.json
+test/
+dist/test/


### PR DESCRIPTION
This should prevent the test folder to npm.

https://packagephobia.now.sh/result?p=fetch-h2