### PR TITLE
Make Response constructor parameters optional

### DIFF
--- a/lib/response.ts
+++ b/lib/response.ts
@@ -72,7 +72,7 @@ export class Response extends Body
 
 	constructor(
 		body: BodyTypes | Body | null = null,
-		init: Partial< ResponseInit > = {},
+		init: Partial< ResponseInit > = { },
 		extra?: Partial< Extra >
 	)
 	{

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -71,8 +71,8 @@ export class Response extends Body
 	public readonly httpVersion: HttpVersion;
 
 	constructor(
-		body: BodyTypes | Body | null,
-		init: Partial< ResponseInit >,
+		body: BodyTypes | Body | null = null,
+		init: Partial< ResponseInit > = {},
 		extra?: Partial< Extra >
 	)
 	{


### PR DESCRIPTION
According to the fetch spec, all parameters of the Response constructor are optional:

- https://developer.mozilla.org/en-US/docs/Web/API/Response/Response
- https://fetch.spec.whatwg.org/#response-class