### PR TITLE
Fix inverted comparison

### DIFF
--- a/lib/context-https.ts
+++ b/lib/context-https.ts
@@ -36,7 +36,7 @@ export function connectTLS(
 	} );
 
 	const orderedProtocols = Buffer.concat(
-		( _protocols.length === 0 ? _protocols : defaultMethod )
+		( _protocols.length !== 0 ? _protocols : defaultMethod )
 		.map( protocol => alpnProtocols[ protocol ] )
 	);
 


### PR DESCRIPTION
I'm incredibly impressed with this module.  Thanks so much for all your efforts and for releasing it for everyone to use.  I *think* there is a bug here, but I'm not completely convinced so proposing the basic change and I'm happy to put more effort in if you can guide me to where it's needed.

My use case is a tool that can make highly configurable requests, and one of the configuration options is whether to use H1 or H2.  I am then setting up a fetch-h2 context using:

```javascript
new FetchContext({ httpProtocol: 'http1', httpsProtocols: [opts.useH2 ? 'http2' : 'http1'] })
```

So, I don't want fetch-h2 to negotiate a protocol for me, I want to pin to a particular one.  However, I found that regardless of the value of the `httpsProtocols` option, fetch was always using H2 anyway.  I believe the problem is that this conditional check is incorrectly inverted.