### PR TITLE
Allow illegal redirect responses

### DIFF
--- a/lib/fetch-http1.ts
+++ b/lib/fetch-http1.ts
@@ -191,10 +191,10 @@ export async function fetchImpl(
 					delete headers[ "set-cookie2" ];
 				}
 
-				if ( isRedirected && !location )
+				if ( isRedirected && !location && !input.allowForbiddenHeaders )
 					return reject( makeIllegalRedirectError( ) );
 
-				if ( !isRedirected || redirect === "manual" )
+				if ( !isRedirected || redirect === "manual" || !location )
 					return resolve(
 						new StreamResponse(
 							contentDecoders,


### PR DESCRIPTION
An HTTP response that has a redirection status but no `Location` header is invalid per the Fetch spec, but it's still a valid HTTP response.  It seems reasonable that a developer may want to receive and parse the response as normal, and there should be an escape valve from the illegal redirect error.

This strikes me as a similar case to other browser-security-model rules of fetch, such as suppressing certain headers, rules which are required in the browser but make fetch-h2 less useful as a generic HTTP client server-side.  Therefore my tentative suggestion is to disable illegal redirect errors if the existing `allowForbiddenHeaders` flag is true.

I also considered suggesting an additional flag, but that seems like overkill to me.  However, it does leave the flag slightly awkwardly named, and I guess `enforceValidation` might be a more generic way to refer to it if you agree to bundle these behaviours into one flag.