### PR TITLE
fix(context-http2): don't guard headers received as part of a PUSH_PROMISE

### DIFF
--- a/lib/context-http2.ts
+++ b/lib/context-http2.ts
@@ -331,7 +331,7 @@ export class H2Context
 		.filter( name => name.charAt( 0 ) === ":" )
 		.forEach( name => { delete requestHeaders[ name ]; } );
 
-		const pushedRequest = new Request( path, { headers: requestHeaders } );
+		const pushedRequest = new Request( path, { headers: requestHeaders, allowForbiddenHeaders: true } );
 
 		ref( );
 

--- a/lib/context-http2.ts
+++ b/lib/context-http2.ts
@@ -331,7 +331,10 @@ export class H2Context
 		.filter( name => name.charAt( 0 ) === ":" )
 		.forEach( name => { delete requestHeaders[ name ]; } );
 
-		const pushedRequest = new Request( path, { headers: requestHeaders, allowForbiddenHeaders: true } );
+		const pushedRequest = new Request(
+			path,
+			{ headers: requestHeaders, allowForbiddenHeaders: true }
+		);
 
 		ref( );
 


### PR DESCRIPTION
Headers received as part of a PUSH_PROMISE should not be subject to forbidden headers check

fix #66