### PR TITLE
convert Headers to extend Map

### DIFF
--- a/test/fetch-h2/context.ts
+++ b/test/fetch-h2/context.ts
@@ -232,8 +232,8 @@ describe( `context (${version} over ${proto.replace( ":", "" )})`, ( ) =>
 				}
 			);
 
-			expect( response.headers.get( "set-cookie" ) ).toBe( null );
-			expect( response.headers.get( "set-cookie2" ) ).toBe( null );
+			expect( response.headers.get( "set-cookie" ) ).toBeUndefined();
+			expect( response.headers.get( "set-cookie2" ) ).toBeUndefined();
 
 			disconnectAll( );
 


### PR DESCRIPTION
the Headers object should extend Map() so that standard mocha/chai specs treat this as a Map and utilise the standard methods