### PR TITLE
fix empty body gzip errors

### DIFF
--- a/lib/response.ts
+++ b/lib/response.ts
@@ -4,6 +4,7 @@ import {
 } from "http2";
 
 import {
+	constants as zlibConstants,
 	createBrotliDecompress,
 	createGunzip,
 	createInflate,
@@ -273,7 +274,7 @@ function handleEncoding(
 		deflate: ( stream: NodeJS.ReadableStream ) =>
 			stream.pipe( createInflate( ) ),
 		gzip: ( stream: NodeJS.ReadableStream ) =>
-			stream.pipe( createGunzip( ) ),
+			stream.pipe( createGunzip( { finishFlush: zlibConstants.Z_SYNC_FLUSH }) ),
 	};
 
 	if ( hasBuiltinBrotli( ) )


### PR DESCRIPTION
set default zlib finishFlush = Z_SYNC_FLUSH to avoid errors from partial or interrupted streams including an empty stream (eg: HEAD)