### PR TITLE
fix(context-http1): fix disconnectAll

### DIFF
--- a/lib/context-http1.ts
+++ b/lib/context-http1.ts
@@ -134,7 +134,7 @@ class OriginPool
 			)
 		);
 
-		const waiting = this.waiting;
+		const waiting = [ ...this.waiting ];
 		this.waiting.length = 0;
 		waiting.forEach( waiter =>
 			// TODO: Better error class + message


### PR DESCRIPTION
There's a bug in the Http1 `disconnectAll` implementation. https://github.com/grantila/fetch-h2/blob/master/lib/context-http1.ts#L141 is never executed because the `waiting` array is truncated on the preceding line.

This PR fixes this by copying the `waiting` array.