### PR TITLE
fix: https connect timeout

### DIFF
--- a/lib/context-https.ts
+++ b/lib/context-https.ts
@@ -1,7 +1,7 @@
 import { SecureClientSessionOptions } from "http2";
 import { connect, ConnectionOptions, TLSSocket } from "tls";
 
-import { HttpProtocols } from "./core";
+import { HttpProtocols, TimeoutError } from "./core";
 import { AltNameMatch, parseOrigin } from "./san";
 
 const alpnProtocols =
@@ -50,9 +50,15 @@ export function connectTLS(
 
 	return new Promise< HttpsSocketResult >( ( resolve, reject ) =>
 	{
+		let handled = false;
 		const socket: TLSSocket = connect( parseInt( port, 10 ), host, opts,
 			( ) =>
 		{
+			if (opts.timeout)
+			{
+				// reset connect timeout
+				socket.setTimeout(0);
+			}
 			const { authorized, authorizationError, alpnProtocol = "" } =
 				socket;
 			const cert = socket.getPeerCertificate( );
@@ -85,5 +91,13 @@ export function connectTLS(
 		} );
 
 		socket.once( "error", reject );
+		socket.once("timeout", () =>
+		{
+			if (!handled) {
+					handled = true;
+					reject(new TimeoutError("connect timed out after " + opts.timeout + " ms"));
+			}
+			socket.destroy();
+		});
 	} );
 }

--- a/test/fetch-h2/index.ts
+++ b/test/fetch-h2/index.ts
@@ -404,6 +404,21 @@ describe( `generic (${protoVersion})`, ( ) =>
 		await server.shutdown( );
 	} );
 
+	it( "should timeout on a slow TLS connect", async ( ) =>
+	{
+		if (proto === "https:")
+		{
+			jest.setTimeout( 1000 );
+
+			const { fetch } = context({ session: { timeout: 50 } } );
+			const eventualResponse = fetch(`${proto}//example.com:81/`);
+
+			const err = await getRejection( eventualResponse );
+
+			expect( err.message ).toContain( "timed out" );
+			}
+	} );
+
 	it( "should be able to POST large (16MiB) stream with known length",
 		async ( ) =>
 	{


### PR DESCRIPTION
fixes TLS connection timeout handling. 

Example:

```js
  const { context } = require('fetch-h2');
  const { fetch } = context({ session: { timeout: 500 } });
  fetch('https://example.com:81/').catch{(err) => console.log(err));
  // prints "connect timed out after 500 ms"
```

partial (`https` only) fix for #99 