### PR TITLE
docs: make it easier to find the allowForbiddenHeaders option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ These are features in `fetch-h2`, that don't exist in the Fetch API. Some things
  * `fetch()` has an extra option, `onTrailers` (of the type `OnTrailers`) which is a callback that will receive trailing headers.
  * The `Request.clone()` member function has an optional `url` argument for the cloned `Request`.
  * The response `text()` and `arrayBuffer()` has an optional argument `allowIncomplete` which defaults to `false`. If set to `true` these function will return incomplete bodies, i.e. "as much as was read" before the stream was prematurely closed (disconnected). If integrity checks are enabled, the functions will throw anyway if the body is incomplete.
- * The `Request` class (options to `fetch`) has an extra property `allowForbiddenHeaders`, which defaults to `false`.
+ * The `Request` class (options to `fetch`) has an extra property `allowForbiddenHeaders`, which defaults to `false`. You can set this to `true` to bypass the "Header guard error: Cannot set forbidden header for requests (...)" error
  * The `Response` class also has an extra property `allowForbiddenHeaders`, which defaults to `false` (or to the value of the `Request` if it was constructed through a `fetch` call, which is the common case).
  * The response object has an extra property `httpVersion` which is either `1` or `2` (numbers), depending on what was negotiated with the server.
  * The `Headers` class (e.g. retried by `{response}.headers`) has a `toJSON` function which converts the headers to a simple JavaScript object.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ These are features in `fetch-h2`, that don't exist in the Fetch API. Some things
  * `fetch()` has an extra option, `onTrailers` (of the type `OnTrailers`) which is a callback that will receive trailing headers.
  * The `Request.clone()` member function has an optional `url` argument for the cloned `Request`.
  * The response `text()` and `arrayBuffer()` has an optional argument `allowIncomplete` which defaults to `false`. If set to `true` these function will return incomplete bodies, i.e. "as much as was read" before the stream was prematurely closed (disconnected). If integrity checks are enabled, the functions will throw anyway if the body is incomplete.
- * The `Request` class (options to `fetch`) has an extra property `allowForbiddenHeaders`, which defaults to `false`. You can set this to `true` to bypass the "Header guard error: Cannot set forbidden header for requests (...)" error
+ * The `Request` class (options to `fetch`) has an extra property `allowForbiddenHeaders`, which defaults to `false`. You can set this to `true` to bypass the "Header guard error: Cannot set forbidden header for requests (...)" error.
  * The `Response` class also has an extra property `allowForbiddenHeaders`, which defaults to `false` (or to the value of the `Request` if it was constructed through a `fetch` call, which is the common case).
  * The response object has an extra property `httpVersion` which is either `1` or `2` (numbers), depending on what was negotiated with the server.
  * The `Headers` class (e.g. retried by `{response}.headers`) has a `toJSON` function which converts the headers to a simple JavaScript object.


### PR DESCRIPTION
I searched through the code looking for the error message before I found this option. Putting the text of the error next to the option should make it much easier to find.