### PR TITLE
test fix server-http1.ts: Remove typescript error in test/server-http1 for RawHeaders

### DIFF
--- a/test/lib/server-http1.ts
+++ b/test/lib/server-http1.ts
@@ -101,7 +101,7 @@ export class ServerHttp1 extends TypedServer< HttpServer | HttpsServer >
 
 			response.statusCode = status;
 
-			for ( const [ key, value ] of Object.entries( rest ) )
+			for ( const [ key, value ] of Object.entries( rest as RawHeaders ) )
 				response.setHeader( key, value );
 		};
 


### PR DESCRIPTION
With this fix, will allow `npm run build` to run successfully on a freshly downloaded repo

```
[0] test/lib/server-http1.ts(105,30): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | number | readonly string[]'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[0] yarn build:ts exited with code 2
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fetch-h2@0.0.0-development build: `concurrently 'yarn build:ts' 'yarn build:cert'`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the fetch-h2@0.0.0-development build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jchristiansen/.npm/_logs/2023-03-05T19_21_40_482Z-debug.log
```
